### PR TITLE
Fix function invokation to joke/joke

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Deployed functions ('doctl sbx fn get <funcName> --url' for URL):
 
 ```
 # execute the function
-> doctl serverless functions invoke joke
+> doctl serverless functions invoke joke/joke
 {
   "body": {
     "response_type": "in_channel",
@@ -41,7 +41,7 @@ Deployed functions ('doctl sbx fn get <funcName> --url' for URL):
 }
 ```
 
-Note the CLI command can be abbreviated as `doctl sls fn invoke joke`.
+Note the CLI command can be abbreviated as `doctl sls fn invoke joke/joke`.
 
 
 ### Learn More


### PR DESCRIPTION
This what happens in my cli:

```
$ doctl sls fn invoke joke                   
Error: Resource by this name exists but is not in this collection. (code XXX)

$ doctl sls fn invoke joke/joke                                                                                                                                           
{
  "body": {
    "response_type": "in_channel",
    "text": "Why are you always smiling? That's just my... regular expression."
  }
}
```
